### PR TITLE
Python error resolution

### DIFF
--- a/respeaker/firmware/tuning.py
+++ b/respeaker/firmware/tuning.py
@@ -106,7 +106,7 @@ class Tuning:
             usb.util.CTRL_IN | usb.util.CTRL_TYPE_VENDOR | usb.util.CTRL_RECIPIENT_DEVICE,
             0, cmd, id, length, self.TIMEOUT)
 
-        response = struct.unpack(b'ii', response.tostring())
+        response = struct.unpack(b'ii', response.tobytes())
 
         if data[2] == 'int':
             result = response[0]


### PR DESCRIPTION
When I cloned the repository and used it as is, I got the following error in Python.

`AttributeError: type object 'array.array' has no attribute 'tostring'`

So I made some changes to [/firmware/tuning.py](https://github.com/machinekoder/respeaker/blob/b47f3daa62e9897c987e0a21389a9916b88bfc07/respeaker/firmware/tuning.py#L109) based on [this site](https://docs.python.org/3/library/array.html#array.array.tobytes).